### PR TITLE
Fix event type names 5-7

### DIFF
--- a/i3ipc.h
+++ b/i3ipc.h
@@ -1100,7 +1100,6 @@ static char const* const i3ipc__global_event_type_name[] = {
     "mode",
     "window",
     "barconfig_update",
-    "version",
     "binding",
     "shutdown",
     "tick"


### PR DESCRIPTION
This string seems to be added by accident. Fixes wrong subscriptions being made for the binding/shutdown/tick events.